### PR TITLE
Fix manual issue form: validation and visible error messages

### DIFF
--- a/app/Livewire/V2/Traits/HandlesIssues.php
+++ b/app/Livewire/V2/Traits/HandlesIssues.php
@@ -10,6 +10,7 @@ use App\Events\IssueDeleted;
 use App\Events\IssueOrderChanged;
 use App\Models\Issue;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
 
 /**
  * Trait für Issue-Management.
@@ -68,12 +69,37 @@ trait HandlesIssues
             return;
         }
 
-        $this->validate([
-            'newIssueTitle' => 'required|string|max:255',
-            'newIssueDescription' => 'nullable|string|max:2000',
-            'newIssueJiraKey' => 'nullable|string|max:50',
-            'newIssueJiraUrl' => 'nullable|url|max:500',
-        ]);
+        $this->newIssueJiraKey = trim($this->newIssueJiraKey ?? '');
+        $this->newIssueJiraUrl = trim($this->newIssueJiraUrl ?? '');
+
+        $jiraKeyRules = ['nullable', 'string', 'max:50'];
+        if ($this->newIssueJiraKey !== '') {
+            $jiraKeyRules[] = Rule::unique('issues', 'jira_key')->where('session_id', $this->session->id);
+        }
+
+        $jiraUrlRules = ['nullable', 'string', 'max:500'];
+        if ($this->newIssueJiraUrl !== '') {
+            $jiraUrlRules[] = 'url';
+        }
+
+        $this->validate(
+            [
+                'newIssueTitle' => 'required|string|max:255',
+                'newIssueDescription' => 'nullable|string|max:2000',
+                'newIssueJiraKey' => $jiraKeyRules,
+                'newIssueJiraUrl' => $jiraUrlRules,
+            ],
+            [
+                'newIssueJiraKey.unique' => 'Dieser Jira Issue Key ist in dieser Session bereits vergeben.',
+                'newIssueJiraUrl.url' => 'Bitte eine gültige URL eingeben oder das Feld leer lassen.',
+            ],
+            [
+                'newIssueTitle' => 'Titel',
+                'newIssueDescription' => 'Beschreibung',
+                'newIssueJiraKey' => 'Jira Issue Key',
+                'newIssueJiraUrl' => 'Jira URL',
+            ],
+        );
 
         $maxPosition = Issue::query()
             ->where('session_id', $this->session->id)

--- a/resources/views/livewire/v2/partials/_drawer-manual.blade.php
+++ b/resources/views/livewire/v2/partials/_drawer-manual.blade.php
@@ -1,5 +1,15 @@
 {{-- Manuelles Issue-Formular --}}
-<form wire:submit="addIssue">
+<form wire:submit.prevent="addIssue" novalidate>
+    @if ($errors->any())
+        <div class="alert alert-error mb-4 text-sm" role="alert">
+            <ul class="list-inside list-disc space-y-0.5">
+                @foreach ($errors->all() as $message)
+                    <li>{{ $message }}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
     <div class="form-control mb-4">
         <label class="label">
             <span class="label-text font-medium">Titel *</span>
@@ -7,8 +17,7 @@
         <input type="text"
                wire:model="newIssueTitle"
                placeholder="Issue-Titel eingeben..."
-               class="input input-bordered w-full"
-               required />
+               class="input input-bordered w-full @error('newIssueTitle') input-error @enderror" />
         @error('newIssueTitle')
             <label class="label">
                 <span class="label-text-alt text-error">{{ $message }}</span>
@@ -22,8 +31,13 @@
         </label>
         <textarea wire:model="newIssueDescription"
                   placeholder="Optionale Beschreibung..."
-                  class="textarea textarea-bordered w-full h-24"
+                  class="textarea textarea-bordered h-24 w-full @error('newIssueDescription') textarea-error @enderror"
         ></textarea>
+        @error('newIssueDescription')
+            <label class="label">
+                <span class="label-text-alt text-error">{{ $message }}</span>
+            </label>
+        @enderror
     </div>
 
     <div class="divider text-xs">Jira (optional)</div>
@@ -35,17 +49,29 @@
         <input type="text"
                wire:model="newIssueJiraKey"
                placeholder="z.B. SAN-1234"
-               class="input input-bordered w-full" />
+               class="input input-bordered w-full @error('newIssueJiraKey') input-error @enderror" />
+        @error('newIssueJiraKey')
+            <label class="label">
+                <span class="label-text-alt text-error">{{ $message }}</span>
+            </label>
+        @enderror
     </div>
 
     <div class="form-control mb-6">
         <label class="label">
             <span class="label-text font-medium">Jira URL</span>
         </label>
-        <input type="url"
+        <input type="text"
+               inputmode="url"
+               autocomplete="url"
                wire:model="newIssueJiraUrl"
                placeholder="https://jira.example.com/browse/SAN-1234"
-               class="input input-bordered w-full" />
+               class="input input-bordered w-full @error('newIssueJiraUrl') input-error @enderror" />
+        @error('newIssueJiraUrl')
+            <label class="label">
+                <span class="label-text-alt text-error">{{ $message }}</span>
+            </label>
+        @enderror
     </div>
 
     <button type="submit" class="btn btn-primary w-full">

--- a/tests/Feature/V2/SessionPageTest.php
+++ b/tests/Feature/V2/SessionPageTest.php
@@ -614,6 +614,44 @@ test('owner can add issue manually', function () {
     Event::assertDispatched(IssueAdded::class);
 });
 
+test('owner can add issue with empty optional jira url and key', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('newIssueTitle', 'No Jira fields');
+    $component->set('newIssueJiraKey', '');
+    $component->set('newIssueJiraUrl', '');
+
+    $component->call('addIssue');
+
+    $issue = Issue::where('session_id', $session->id)->where('title', 'No Jira fields')->first();
+    expect($issue)->not->toBeNull();
+    expect($issue->jira_key)->toBeNull();
+    expect($issue->jira_url)->toBeNull();
+});
+
+test('add issue rejects duplicate jira key in same session', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+
+    Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::NEW,
+        'jira_key' => 'DUP-KEY',
+        'position' => 0,
+    ]);
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('newIssueTitle', 'Second');
+    $component->set('newIssueJiraKey', 'DUP-KEY');
+
+    $component->call('addIssue');
+
+    $component->assertHasErrors(['newIssueJiraKey']);
+    expect(Issue::where('title', 'Second')->exists())->toBeFalse();
+});
+
 test('owner can delete issue', function () {
     $session = createTestSession();
     $owner = $session->owner;


### PR DESCRIPTION
## Bug

Submitting the **manual “add issue”** form with a **title only** and **empty optional Jira fields** could fail server-side validation without showing errors next to the Jira fields. The UI looked like “nothing happens” because only the title field had `@error` output.

**Cause:** Livewire validates component properties directly. An empty Jira URL is `''`, not `null`. The rules used `nullable|url` for `newIssueJiraUrl`. An empty string is not treated as `null` here, so the `url` rule still ran and failed, while the Blade template did not surface `@error` for `newIssueJiraUrl` / `newIssueJiraKey`.

## Reproduction (before fix)

1. Log in as the **session owner** and open a session voting page (e.g. `/sessions/{inviteCode}/voting`).
2. Open the flow to **add an issue manually** (drawer / manual tab).
3. Fill **only Title** (e.g. `test`).
4. Leave **Jira Issue Key** and **Jira URL** **empty**.
5. Submit **Add issue**.

**Expected (buggy):** No visible validation feedback on Jira fields; issue not created (or unclear failure).

## Fix

- Trim optional Jira fields; apply the `url` rule and `unique` rule for Jira key **only when** the value is non-empty.
- Add **visible validation**: summary alert + per-field `@error` styling, `wire:submit.prevent`, `novalidate`, and Jira URL as a text input with `inputmode="url"` (avoid awkward browser `type="url"` behavior).
- Add **Pest** coverage: empty optional Jira fields allowed; duplicate Jira key in the same session rejected with validation errors.

## How to verify

Run tests: `php artisan test tests/Feature/V2/SessionPageTest.php` (includes the new cases for empty Jira fields and duplicate key).