### PR TITLE
Add local-only dev user seeding

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        if (app()->environment('local')) {
+            $this->call(DevUsersSeeder::class);
+        }
     }
 }

--- a/database/seeders/DevUsersSeeder.php
+++ b/database/seeders/DevUsersSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+/**
+ * Fixed credentials for local development only. Run via `php artisan db:seed` when APP_ENV=local.
+ *
+ * @see DatabaseSeeder
+ */
+class DevUsersSeeder extends Seeder
+{
+    /**
+     * @return list<array{name: string, email: string, password: string}>
+     */
+    public static function definitions(): array
+    {
+        return [
+            ['name' => 'Local Dev', 'email' => 'dev@planning-poker.test', 'password' => 'password'],
+            ['name' => 'Tester One', 'email' => 'tester1@planning-poker.test', 'password' => 'password'],
+            ['name' => 'Tester Two', 'email' => 'tester2@planning-poker.test', 'password' => 'password'],
+        ];
+    }
+
+    public function run(): void
+    {
+        foreach (self::definitions() as $row) {
+            $plain = $row['password'];
+            unset($row['password']);
+
+            User::updateOrCreate(
+                ['email' => $row['email']],
+                [
+                    ...$row,
+                    'password' => bcrypt($plain),
+                    'email_verified_at' => now(),
+                ],
+            );
+        }
+    }
+}

--- a/tests/Feature/DevUsersSeederTest.php
+++ b/tests/Feature/DevUsersSeederTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Models\User;
+use Database\Seeders\DevUsersSeeder;
+use Illuminate\Support\Facades\Hash;
+
+test('dev users seeder upserts expected users and passwords', function () {
+    $this->seed(DevUsersSeeder::class);
+
+    foreach (DevUsersSeeder::definitions() as $row) {
+        $user = User::where('email', $row['email'])->first();
+        expect($user)->not->toBeNull()
+            ->and($user->name)->toBe($row['name'])
+            ->and(Hash::check($row['password'], $user->password))->toBeTrue()
+            ->and($user->email_verified_at)->not->toBeNull();
+    }
+});


### PR DESCRIPTION
## Summary

Adds a **local-only** database seed with **three fixed dev users** (known email + password) so new contributors can log in immediately after `php artisan db:seed` in `APP_ENV=local`. The previous `DatabaseSeeder` only contained commented-out factory examples and did not create any accounts.

## Behaviour

- **`DevUsersSeeder`**: defines three users via `definitions()` (reused in tests), uses `updateOrCreate` by email, bcrypts password, sets `email_verified_at` (app uses `MustVerifyEmail`).
- **`DatabaseSeeder`**: calls `DevUsersSeeder` **only when** `app()->environment('local')` so staging/production `db:seed` does not create these accounts by default.

## Seeded accounts (local)

| Email | Password |
|-------|------------|
| `dev@planning-poker.test` | `password` |
| `tester1@planning-poker.test` | `password` |
| `tester2@planning-poker.test` | `password` |

## How to use

```bash
php artisan db:seed
# or
php artisan db:seed --class=DevUsersSeeder