### PR TITLE
Celebrate unanimous estimates with confetti on card reveal (v2 live voting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Fallback without Herd:
 php artisan serve
 ```
 
+## Live voting highlights (v2)
+
+When the owner reveals votes and every member in the **Voter** role has submitted the same estimate, the browser briefly shows confetti. Viewers and the session owner are not counted toward that unanimity check.
+
 ## Session Archiving
 
 - Run `php artisan migrate` after pulling the latest changes to add the `archived_at` column on `sessions`.

--- a/app/Livewire/V2/Traits/HandlesVoting.php
+++ b/app/Livewire/V2/Traits/HandlesVoting.php
@@ -88,6 +88,7 @@ trait HandlesVoting
     {
         $this->votesRevealed = true;
         $this->loadVotedUsers();
+        $this->dispatchUnanimousRevealIfNeeded();
     }
 
     public function handleHideVotes(): void
@@ -145,6 +146,7 @@ trait HandlesVoting
 
         $this->votesRevealed = true;
         $this->loadVotedUsers();
+        $this->dispatchUnanimousRevealIfNeeded();
 
         broadcast(new RevealVotes($this->session->invite_code))->toOthers();
     }
@@ -336,5 +338,51 @@ trait HandlesVoting
         $this->votedUserIds = $votes->pluck('user_id')->all();
         $this->votesByUser = $votes->pluck('value', 'user_id')->all();
         $this->myVote = $this->votesByUser[Auth::id()] ?? null;
+    }
+
+    /**
+     * True when every eligible voter has voted and all values match.
+     */
+    private function allEligibleVotersAgree(): bool
+    {
+        if (! $this->currentIssue) {
+            return false;
+        }
+
+        $voterIds = $this->session->users()
+            ->get()
+            ->filter(fn(User $user) => $this->session->canUserVote($user))
+            ->pluck('id')
+            ->all();
+
+        if ($voterIds === []) {
+            return false;
+        }
+
+        foreach ($voterIds as $userId) {
+            if (! array_key_exists($userId, $this->votesByUser)) {
+                return false;
+            }
+        }
+
+        $firstId = $voterIds[0];
+        $firstValue = (int) $this->votesByUser[$firstId];
+
+        foreach ($voterIds as $userId) {
+            if ((int) $this->votesByUser[$userId] !== $firstValue) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function dispatchUnanimousRevealIfNeeded(): void
+    {
+        if (! $this->allEligibleVotersAgree()) {
+            return;
+        }
+
+        $this->dispatch('planning-poker-unanimous');
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
                 "@tailwindcss/typography": "^0.5.9",
                 "alpinejs": "^3.12.1",
                 "axios": "^1.13.1",
+                "canvas-confetti": "^1.9.4",
                 "daisyui": "^5.3.10",
                 "laravel-echo": "^2.2.4",
                 "pusher-js": "^8.4.0"
@@ -909,8 +910,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
             "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@tailwindcss/forms": {
             "version": "0.5.11",
@@ -1493,6 +1493,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -1593,6 +1594,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/canvas-confetti": {
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.4.tgz",
+            "integrity": "sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==",
+            "license": "ISC",
+            "funding": {
+                "type": "donate",
+                "url": "https://www.paypal.me/kirilvatev"
+            }
         },
         "node_modules/class-utils": {
             "version": "0.3.6",
@@ -1842,7 +1853,6 @@
             "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
             "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.4.1",
@@ -1856,7 +1866,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1874,7 +1883,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
             "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -1896,7 +1904,6 @@
             "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
             "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             }
@@ -3750,6 +3757,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -3800,6 +3808,7 @@
             "resolved": "https://registry.npmjs.org/pusher-js/-/pusher-js-8.5.0.tgz",
             "integrity": "sha512-V7uzGi9bqOOOyM/6IkJdpFyjGZj7llz1v0oWnYkZKcYLvbz6VcHVLmzKqkvegjuMumpfIEKGLmWHwFb39XFCpw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tweetnacl": "^1.0.3"
             }
@@ -4266,7 +4275,6 @@
             "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
             "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.4.1",
@@ -4282,7 +4290,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -4300,7 +4307,6 @@
             "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
             "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.4.1"
@@ -4314,7 +4320,6 @@
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -4505,7 +4510,8 @@
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
             "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tapable": {
             "version": "2.3.2",
@@ -4561,6 +4567,7 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4790,6 +4797,7 @@
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -4930,6 +4938,7 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -4948,7 +4957,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
             "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
-            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "@tailwindcss/typography": "^0.5.9",
         "alpinejs": "^3.12.1",
         "axios": "^1.13.1",
+        "canvas-confetti": "^1.9.4",
         "daisyui": "^5.3.10",
         "laravel-echo": "^2.2.4",
         "pusher-js": "^8.4.0"

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,5 +1,26 @@
 import './bootstrap'
 
+import confetti from 'canvas-confetti'
+
+/**
+ * Called from Livewire SessionPage @script when all eligible voters agreed.
+ */
+window.planningPokerPlayUnanimousConfetti = () => {
+    confetti({
+        particleCount: 125,
+        spread: 70,
+        origin: { y: 0.62 },
+    })
+    window.setTimeout(() => {
+        confetti({
+            particleCount: 85,
+            angle: 60,
+            spread: 55,
+            origin: { y: 0.68 },
+        })
+    }, 200)
+}
+
 // import Alpine from 'alpinejs'
 // import Clipboard from '@ryangjchandler/alpine-clipboard'
 

--- a/resources/views/livewire/v2/session-page.blade.php
+++ b/resources/views/livewire/v2/session-page.blade.php
@@ -130,5 +130,9 @@
             }
         }, 200);
     });
+
+    $wire.on('planning-poker-unanimous', () => {
+        window.planningPokerPlayUnanimousConfetti?.();
+    });
 </script>
 @endscript

--- a/tests/Feature/V2/SessionPageTest.php
+++ b/tests/Feature/V2/SessionPageTest.php
@@ -214,6 +214,136 @@ test('owner can reveal votes when at least one vote exists', function () {
     Event::assertDispatched(RevealVotes::class);
 });
 
+test('reveal dispatches planning-poker-unanimous when all eligible voters voted the same', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+    $voter1 = User::factory()->create();
+    $voter2 = User::factory()->create();
+    $session->users()->attach($voter1->id, ['role' => SessionParticipantRole::Voter->value]);
+    $session->users()->attach($voter2->id, ['role' => SessionParticipantRole::Voter->value]);
+    $issue = Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::VOTING,
+    ]);
+
+    Vote::factory()->create([
+        'user_id' => $voter1->id,
+        'issue_id' => $issue->id,
+        'value' => 5,
+    ]);
+    Vote::factory()->create([
+        'user_id' => $voter2->id,
+        'issue_id' => $issue->id,
+        'value' => 5,
+    ]);
+
+    Event::fake([RevealVotes::class]);
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('currentIssue', $issue);
+    $component->set('votedUserIds', [$voter1->id, $voter2->id]);
+    $component->set('votesByUser', [$voter1->id => 5, $voter2->id => 5]);
+
+    $component->call('revealVotes');
+
+    $component->assertDispatched('planning-poker-unanimous');
+});
+
+test('reveal does not dispatch planning-poker-unanimous when eligible voters disagree', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+    $voter1 = User::factory()->create();
+    $voter2 = User::factory()->create();
+    $session->users()->attach($voter1->id, ['role' => SessionParticipantRole::Voter->value]);
+    $session->users()->attach($voter2->id, ['role' => SessionParticipantRole::Voter->value]);
+    $issue = Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::VOTING,
+    ]);
+
+    Vote::factory()->create([
+        'user_id' => $voter1->id,
+        'issue_id' => $issue->id,
+        'value' => 5,
+    ]);
+    Vote::factory()->create([
+        'user_id' => $voter2->id,
+        'issue_id' => $issue->id,
+        'value' => 8,
+    ]);
+
+    Event::fake([RevealVotes::class]);
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('currentIssue', $issue);
+    $component->set('votedUserIds', [$voter1->id, $voter2->id]);
+    $component->set('votesByUser', [$voter1->id => 5, $voter2->id => 8]);
+
+    $component->call('revealVotes');
+
+    $component->assertNotDispatched('planning-poker-unanimous');
+});
+
+test('reveal dispatches planning-poker-unanimous when only voters must agree and viewer ignores unanimity', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+    $voter = User::factory()->create();
+    $viewer = User::factory()->create();
+    $session->users()->attach($voter->id, ['role' => SessionParticipantRole::Voter->value]);
+    $session->users()->attach($viewer->id, ['role' => SessionParticipantRole::Viewer->value]);
+    $issue = Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::VOTING,
+    ]);
+
+    Vote::factory()->create([
+        'user_id' => $voter->id,
+        'issue_id' => $issue->id,
+        'value' => 3,
+    ]);
+
+    Event::fake([RevealVotes::class]);
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('currentIssue', $issue);
+    $component->set('votedUserIds', [$voter->id]);
+    $component->set('votesByUser', [$voter->id => 3]);
+
+    $component->call('revealVotes');
+
+    $component->assertDispatched('planning-poker-unanimous');
+});
+
+test('reveal does not dispatch planning-poker-unanimous when an eligible voter has not voted', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+    $voter1 = User::factory()->create();
+    $voter2 = User::factory()->create();
+    $session->users()->attach($voter1->id, ['role' => SessionParticipantRole::Voter->value]);
+    $session->users()->attach($voter2->id, ['role' => SessionParticipantRole::Voter->value]);
+    $issue = Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::VOTING,
+    ]);
+
+    Vote::factory()->create([
+        'user_id' => $voter1->id,
+        'issue_id' => $issue->id,
+        'value' => 5,
+    ]);
+
+    Event::fake([RevealVotes::class]);
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('currentIssue', $issue);
+    $component->set('votedUserIds', [$voter1->id]);
+    $component->set('votesByUser', [$voter1->id => 5]);
+
+    $component->call('revealVotes');
+
+    $component->assertNotDispatched('planning-poker-unanimous');
+});
+
 test('owner can hide votes after revealing', function () {
     $session = createTestSession();
     $owner = $session->owner;


### PR DESCRIPTION
## Summary

When the facilitator reveals votes on the v2 session page, we should give the team quick positive feedback if **everyone who is allowed to vote** picked the **same** card.

## Behaviour

- **Trigger:** Owner clicks reveal and, for the current issue, every member in the **Voter** role has submitted a vote and all values are identical (integers).
- **Not counted:** Session owner (PO) and **Viewer** role members are excluded from the unanimity check (same rules as `Session::canUserVote`).
- **No celebration:** Different values, at least one eligible voter missing, or no eligible voters.
- **UX:** Short, non-blocking canvas-based confetti for all clients that receive the reveal (owner + listeners).

## Technical notes

- Server decides unanimity after loading votes; Livewire dispatches a browser event; `canvas-confetti` runs from the bundled JS helper used by the session page script.

## Verification

1. Open a v2 session with two or more voters; pick the same card; reveal → confetti.
2. Same setup with different cards → no confetti.
3. One voter still missing → no confetti.
4. Mix of voter + viewer, only voter voted (single eligible voter) → confetti when that vote exists (unanimous among voters).
