### PR TITLE
chore(ci): run Pint and Pest on PRs via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -36,7 +36,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache Composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@v5
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -47,7 +47,7 @@ jobs:
               run: composer install --prefer-dist --no-interaction --no-progress
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: '22'
                   cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,11 @@ jobs:
     quality:
         name: Pint & Pest
         runs-on: ubuntu-latest
+        env:
+            # No .env in CI — default broadcaster is "reverb" (needs REVERB_*); use null for install + artisan
+            BROADCAST_DRIVER: 'null'
+            # Satisfy Laravel when config/cache references encryption (composer scripts run package:discover)
+            APP_KEY: 'base64:MtBvQOOQTmI5iTv900mPHWnzJjjyoG8q5hD1ZcH+0eg='
 
         steps:
             - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,17 @@ jobs:
             - name: Install Composer dependencies
               run: composer install --prefer-dist --no-interaction --no-progress
 
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '22'
+                  cache: npm
+
+            - name: Install npm dependencies and build assets
+              run: |
+                  npm ci
+                  npm run build
+
             - name: Run Pint
               run: vendor/bin/pint --test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+    pull_request:
+    push:
+        branches:
+            - main
+
+concurrency:
+    group: ci-${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    quality:
+        name: Pint & Pest
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.4'
+                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
+                  coverage: none
+
+            - name: Get Composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-composer-
+
+            - name: Install Composer dependencies
+              run: composer install --prefer-dist --no-interaction --no-progress
+
+            - name: Run Pint
+              run: vendor/bin/pint --test
+
+            - name: Run tests
+              run: vendor/bin/pest


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that runs on **pull requests** and **pushes to `main`**.

## Checks
- `vendor/bin/pint --test` — code style (no fixes applied in CI)
- `vendor/bin/pest` — feature tests (SQLite in-memory per `phpunit.xml`)

## Notes
- Uses PHP 8.4 + Composer cache
- Concurrency cancels superseded runs on the same branch
