### PR TITLE
Display parent epic information in issue lists and detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ Homestead.yaml
 auth.json
 npm-debug.log
 yarn-error.log
+jira-rest-client.log
 /.fleet
 /.idea
 /.vscode

--- a/app/Livewire/V2/Traits/HandlesJiraImport.php
+++ b/app/Livewire/V2/Traits/HandlesJiraImport.php
@@ -11,6 +11,8 @@ use App\Services\JiraService;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
 
+use function app;
+
 /**
  * Trait für Jira-Import-Funktionalität.
  *
@@ -20,13 +22,18 @@ trait HandlesJiraImport
 {
     /** @var array<int, array{id: string, name: string, jql: string}> */
     public array $jiraFilters = [];
+
     public bool $jiraFiltersLoaded = false;
+
     public bool $jiraLoading = false;
+
     public string $jiraInput = '';
+
     public string $jiraError = '';
+
     public string $jiraSuccess = '';
 
-    /** @var array<int, array{key: string, title: string, description: ?string, url: string, estimate_unit: string, issue_type?: ?string, alreadyImported: bool}> */
+    /** @var array<int, array{key: string, title: string, description: ?string, url: string, estimate_unit: string, issue_type?: ?string, parent_key?: ?string, parent_title?: ?string, parent_url?: ?string, alreadyImported: bool}> */
     public array $jiraTickets = [];
 
     /** @var array<string> */
@@ -53,7 +60,7 @@ trait HandlesJiraImport
      */
     protected function onJiraTabOpened(): void
     {
-        if (!$this->jiraFiltersLoaded && $this->hasJiraCredentials()) {
+        if (! $this->jiraFiltersLoaded && $this->hasJiraCredentials()) {
             $this->loadJiraFilters();
         }
     }
@@ -69,15 +76,23 @@ trait HandlesJiraImport
     }
 
     /**
+     * Resolve the JiraService for the current user.
+     */
+    protected function jiraService(): JiraService
+    {
+        return app(JiraService::class, ['user' => Auth::user()]);
+    }
+
+    /**
      * Lädt die Favoriten-Filter des Users aus Jira.
      */
     public function loadJiraFilters(bool $forceRefresh = false): void
     {
-        if (!$this->hasJiraCredentials()) {
+        if (! $this->hasJiraCredentials()) {
             return;
         }
 
-        if ($this->jiraFiltersLoaded && !$forceRefresh) {
+        if ($this->jiraFiltersLoaded && ! $forceRefresh) {
             return;
         }
 
@@ -85,7 +100,7 @@ trait HandlesJiraImport
         $this->jiraError = '';
 
         try {
-            $jiraService = new JiraService(Auth::user());
+            $jiraService = $this->jiraService();
             $this->jiraFilters = $jiraService->getFavoriteFilters();
             $this->jiraFiltersLoaded = true;
 
@@ -113,7 +128,7 @@ trait HandlesJiraImport
      */
     public function loadFromFilter(string $filterId): void
     {
-        if (!$this->hasJiraCredentials()) {
+        if (! $this->hasJiraCredentials()) {
             return;
         }
 
@@ -123,10 +138,10 @@ trait HandlesJiraImport
         $this->selectedJiraTickets = [];
 
         try {
-            $jiraService = new JiraService(Auth::user());
+            $jiraService = $this->jiraService();
             $jql = $jiraService->getFilterJql($filterId);
 
-            if (!$jql) {
+            if (! $jql) {
                 $this->jiraError = 'Filter-JQL konnte nicht geladen werden.';
                 $this->jiraLoading = false;
 
@@ -147,7 +162,7 @@ trait HandlesJiraImport
      */
     public function loadFromInput(): void
     {
-        if (!$this->hasJiraCredentials() || empty(trim($this->jiraInput))) {
+        if (! $this->hasJiraCredentials() || empty(trim($this->jiraInput))) {
             return;
         }
 
@@ -157,7 +172,7 @@ trait HandlesJiraImport
         $this->selectedJiraTickets = [];
 
         try {
-            $jiraService = new JiraService(Auth::user());
+            $jiraService = $this->jiraService();
             $parsed = $jiraService->parseJiraInput($this->jiraInput);
 
             switch ($parsed['type']) {
@@ -202,7 +217,7 @@ trait HandlesJiraImport
     /**
      * Mapped Jira-Issues zu Ticket-Array.
      *
-     * @param array<object> $issues
+     * @param  array<object>  $issues
      */
     private function mapIssuesToTickets(array $issues, JiraService $jiraService): void
     {
@@ -223,6 +238,9 @@ trait HandlesJiraImport
                 'url' => $mapped['jira_url'],
                 'estimate_unit' => $mapped['estimate_unit'] ?? 'sp',
                 'issue_type' => $mapped['issue_type'] ?? null,
+                'parent_key' => $mapped['parent_key'] ?? null,
+                'parent_title' => $mapped['parent_title'] ?? null,
+                'parent_url' => $mapped['parent_url'] ?? null,
                 'alreadyImported' => $alreadyImported,
             ];
         }
@@ -238,7 +256,7 @@ trait HandlesJiraImport
     public function selectAllJiraTickets(): void
     {
         $this->selectedJiraTickets = collect($this->jiraTickets)
-            ->filter(fn($t) => !$t['alreadyImported'])
+            ->filter(fn($t) => ! $t['alreadyImported'])
             ->pluck('key')
             ->all();
     }
@@ -270,7 +288,7 @@ trait HandlesJiraImport
             ->max('position') ?? -1;
 
         foreach ($this->jiraTickets as &$ticket) {
-            if (!in_array($ticket['key'], $this->selectedJiraTickets)) {
+            if (! in_array($ticket['key'], $this->selectedJiraTickets)) {
                 continue;
             }
 
@@ -290,6 +308,9 @@ trait HandlesJiraImport
                 'jira_url' => $ticket['url'],
                 'estimate_unit' => $ticket['estimate_unit'] ?? 'sp',
                 'issue_type' => $ticket['issue_type'] ?? null,
+                'parent_key' => $ticket['parent_key'] ?? null,
+                'parent_title' => $ticket['parent_title'] ?? null,
+                'parent_url' => $ticket['parent_url'] ?? null,
             ]);
 
             $ticket['alreadyImported'] = true;
@@ -321,7 +342,7 @@ trait HandlesJiraImport
      */
     public function refreshIssueFromJira(int $issueId): void
     {
-        if (Auth::id() !== $this->session->owner_id || !$this->hasJiraCredentials()) {
+        if (Auth::id() !== $this->session->owner_id || ! $this->hasJiraCredentials()) {
             return;
         }
 
@@ -330,7 +351,7 @@ trait HandlesJiraImport
             ->whereKey($issueId)
             ->first();
 
-        if (!$issue || empty($issue->jira_key)) {
+        if (! $issue || empty($issue->jira_key)) {
             return;
         }
 
@@ -339,12 +360,13 @@ trait HandlesJiraImport
         $this->jiraSuccess = '';
 
         try {
-            $jiraService = new JiraService(Auth::user());
+            $jiraService = $this->jiraService();
             $jiraIssue = $jiraService->getIssueByKey($issue->jira_key);
 
-            if (!$jiraIssue) {
+            if (! $jiraIssue) {
                 $this->jiraError = 'Ticket konnte nicht aus Jira geladen werden.';
                 $this->jiraRefreshing = false;
+
                 return;
             }
 
@@ -355,6 +377,9 @@ trait HandlesJiraImport
             $issue->jira_url = $mapped['jira_url'] ?? $issue->jira_url;
             $issue->estimate_unit = $mapped['estimate_unit'] ?? ($issue->estimate_unit ?? 'sp');
             $issue->issue_type = $mapped['issue_type'] ?? $issue->issue_type;
+            $issue->parent_key = $mapped['parent_key'] ?? $issue->parent_key;
+            $issue->parent_title = $mapped['parent_title'] ?? $issue->parent_title;
+            $issue->parent_url = $mapped['parent_url'] ?? $issue->parent_url;
             $issue->save();
 
             // Keep state fresh
@@ -374,7 +399,7 @@ trait HandlesJiraImport
      */
     public function refreshAllJiraIssues(): void
     {
-        if (Auth::id() !== $this->session->owner_id || !$this->hasJiraCredentials()) {
+        if (Auth::id() !== $this->session->owner_id || ! $this->hasJiraCredentials()) {
             return;
         }
 
@@ -395,7 +420,7 @@ trait HandlesJiraImport
         $updated = 0;
 
         try {
-            $jiraService = new JiraService(Auth::user());
+            $jiraService = $this->jiraService();
             $keys = array_values(array_map('strval', $keysById));
             $jiraIssues = $jiraService->getIssuesByKeys($keys);
 
@@ -416,7 +441,7 @@ trait HandlesJiraImport
                     ->whereKey((int) $issueId)
                     ->first();
 
-                if (!$issue) {
+                if (! $issue) {
                     continue;
                 }
 
@@ -425,6 +450,9 @@ trait HandlesJiraImport
                 $issue->jira_url = $mapped['jira_url'] ?? $issue->jira_url;
                 $issue->estimate_unit = $mapped['estimate_unit'] ?? ($issue->estimate_unit ?? 'sp');
                 $issue->issue_type = $mapped['issue_type'] ?? $issue->issue_type;
+                $issue->parent_key = $mapped['parent_key'] ?? $issue->parent_key;
+                $issue->parent_title = $mapped['parent_title'] ?? $issue->parent_title;
+                $issue->parent_url = $mapped['parent_url'] ?? $issue->parent_url;
                 $issue->save();
 
                 $updated++;

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -4,10 +4,12 @@ namespace App\Models;
 
 use App\Enums\IssueStatus;
 use Database\Factories\IssueFactory;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 
 /**
@@ -18,18 +20,20 @@ use Illuminate\Support\Str;
  * @property string|null $description
  * @property string $status
  * @property int $session_id
- * @property \Illuminate\Support\Carbon|null $created_at
- * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  * @property int|null $storypoints
  * @property string $estimate_unit
  * @property string|null $issue_type
+ * @property string|null $parent_key
+ * @property string|null $parent_title
+ * @property string|null $parent_url
  * @property string|null $jira_key
  * @property string|null $jira_url
- *
  * @property-read float $average_vote
  * @property-read string $title_html
- * @property-read \App\Models\Session $session
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Vote> $votes
+ * @property-read Session $session
+ * @property-read Collection<int, Vote> $votes
  * @property-read int|null $votes_count
  *
  * @method static \Illuminate\Database\Eloquent\Builder|Issue newModelQuery()
@@ -59,6 +63,9 @@ class Issue extends Model
         'storypoints',
         'estimate_unit',
         'issue_type',
+        'parent_key',
+        'parent_title',
+        'parent_url',
         'jira_key',
         'jira_url',
         'position',
@@ -89,7 +96,8 @@ class Issue extends Model
         // If we have Jira URL and key, create link
         if ($this->jira_url && $this->jira_key) {
             $browserUrl = $this->getJiraBrowserUrl();
-            return "<a href='{$browserUrl}' class='hover:underline text-accent' target='_blank'>{$this->jira_key}<br>" . Str::limit($this->title, 100) . "</a>";
+
+            return "<a href='{$browserUrl}' class='hover:underline text-accent' target='_blank'>{$this->jira_key}<br>" . Str::limit($this->title, 100) . '</a>';
         }
 
         // Fallback to existing URL parsing logic
@@ -118,6 +126,7 @@ class Issue extends Model
         // If it's an API URL (contains /rest/api/), convert it
         if (str_contains($this->jira_url, '/rest/api/')) {
             $baseUrl = preg_replace('#/rest/api/.*#', '', $this->jira_url);
+
             return $baseUrl . '/browse/' . $this->jira_key;
         }
 
@@ -144,6 +153,7 @@ class Issue extends Model
             function ($matches) {
                 $attachmentId = $matches[1];
                 $proxyUrl = route('jira.attachment.proxy', ['attachmentId' => $attachmentId]) . '?issue_id=' . $this->id;
+
                 return $proxyUrl;
             },
             $html,
@@ -155,6 +165,7 @@ class Issue extends Model
             function ($matches) {
                 $attachmentId = $matches[2];
                 $proxyUrl = route('jira.attachment.proxy', ['attachmentId' => $attachmentId]) . '?issue_id=' . $this->id;
+
                 return 'src="' . $proxyUrl . '"';
             },
             $html,

--- a/app/Services/JiraService.php
+++ b/app/Services/JiraService.php
@@ -4,12 +4,15 @@ namespace App\Services;
 
 use App\Models\User;
 use Illuminate\Support\Facades\Log;
+use JiraRestApi\Configuration\ArrayConfiguration;
+use JiraRestApi\Issue\IssueField;
 use JiraRestApi\Issue\IssueService;
 use JiraRestApi\JiraException;
 
 class JiraService
 {
     private ?IssueService $issueService = null;
+
     private ?User $user = null;
 
     public function __construct(User $user)
@@ -21,7 +24,7 @@ class JiraService
     private function initializeIssueService(): void
     {
         // Use user-specific credentials
-        $config = new \JiraRestApi\Configuration\ArrayConfiguration([
+        $config = new ArrayConfiguration([
             'jiraHost' => $this->user->jira_url,
             'jiraUser' => $this->user->jira_user,
             'jiraPassword' => $this->user->jira_api_key,
@@ -33,20 +36,20 @@ class JiraService
     /**
      * Search for Jira issues by project key and status
      *
-     * @param string $projectKey
-     * @param string $status
      * @return array<int, object>
+     *
      * @throws JiraException
      */
     public function searchIssuesByProjectAndStatus(string $projectKey, string $status): array
     {
-        if (!$this->issueService) {
+        if (! $this->issueService) {
             throw new \RuntimeException('Jira service not initialized. Please configure your Jira credentials in your profile.');
         }
 
         $jql = "project = \"{$projectKey}\" AND status = \"{$status}\" ORDER BY created DESC";
         try {
             $response = $this->issueService->search(jql: $jql, maxResults: 100, expand: 'renderedFields');
+
             return $response->getIssues();
         } catch (JiraException $e) {
             Log::error('Jira API error: ' . $e->getMessage());
@@ -57,8 +60,7 @@ class JiraService
     /**
      * Map Jira issue to array format for Issue model
      *
-     * @param object $jiraIssue
-     * @return array<string, string|null>
+     * @return array{title: string, description: string|null, jira_key: string, jira_url: string, issue_type: string|null, parent_key: string|null, parent_title: string|null, parent_url: string|null, estimate_unit: string}
      */
     public function mapJiraIssueToArray(object $jiraIssue): array
     {
@@ -66,6 +68,7 @@ class JiraService
         $browserUrl = $this->convertApiUrlToBrowserUrl($jiraIssue->self ?? '', $issueKey);
         $issueTypeName = (string) ($jiraIssue->fields->issuetype->name ?? '');
         $isSpike = mb_strtolower(trim($issueTypeName)) === 'spike';
+        $parent = $this->mapParentIssue($jiraIssue);
 
         return [
             'title' => $jiraIssue->fields->summary ?? 'No title',
@@ -73,17 +76,40 @@ class JiraService
             'jira_key' => $issueKey,
             'jira_url' => $browserUrl,
             'issue_type' => $issueTypeName ?: null,
+            'parent_key' => $parent['key'],
+            'parent_title' => $parent['title'],
+            'parent_url' => $parent['url'],
             // Spike issues should be estimated in hours (not story points)
             'estimate_unit' => $isSpike ? 'hours' : 'sp',
         ];
     }
 
     /**
-     * Convert Jira API URL to browser URL
+     * Map a Jira parent issue to a normalized array.
      *
-     * @param string $apiUrl
-     * @param string $issueKey
-     * @return string
+     * @return array{key: string|null, title: string|null, url: string|null}
+     */
+    private function mapParentIssue(object $jiraIssue): array
+    {
+        $parent = $jiraIssue->fields->parent ?? null;
+
+        if (! $parent || empty($parent->key)) {
+            return ['key' => null, 'title' => null, 'url' => null];
+        }
+
+        $parentKey = (string) $parent->key;
+        $parentTitle = (string) ($parent->fields->summary ?? '');
+        $parentUrl = $this->convertApiUrlToBrowserUrl($parent->self ?? '', $parentKey);
+
+        return [
+            'key' => $parentKey,
+            'title' => $parentTitle ?: null,
+            'url' => $parentUrl ?: null,
+        ];
+    }
+
+    /**
+     * Convert Jira API URL to browser URL
      */
     private function convertApiUrlToBrowserUrl(string $apiUrl, string $issueKey): string
     {
@@ -103,14 +129,15 @@ class JiraService
     /**
      * Update story points for a Jira issue
      *
-     * @param string $issueKey The Jira issue key (e.g., "PROJECT-123")
-     * @param int $storyPoints The story points value to set
+     * @param  string  $issueKey  The Jira issue key (e.g., "PROJECT-123")
+     * @param  int  $storyPoints  The story points value to set
      * @return bool True if successful, false otherwise
      */
     public function updateStoryPoints(string $issueKey, int $storyPoints): bool
     {
-        if (!$this->issueService) {
+        if (! $this->issueService) {
             Log::error('Jira service not initialized for updating story points');
+
             return false;
         }
 
@@ -136,12 +163,12 @@ class JiraService
             }
 
             // If no standard field found, try to use REST API to find it
-            if (!$storyPointsField) {
+            if (! $storyPointsField) {
                 return $this->updateStoryPointsViaRestApi($issueKey, $storyPoints);
             }
 
             // Update using IssueService with IssueField
-            $issueField = new \JiraRestApi\Issue\IssueField(true);
+            $issueField = new IssueField(true);
 
             // Use addCustomField if it's a custom field, otherwise set directly
             if (str_starts_with($storyPointsField, 'customfield_')) {
@@ -155,14 +182,17 @@ class JiraService
             $this->issueService->update($issueKey, $issueField);
 
             Log::info("Successfully updated story points for {$issueKey} to {$storyPoints}");
+
             return true;
 
         } catch (JiraException $e) {
             Log::error("Failed to update story points for {$issueKey}: " . $e->getMessage());
+
             // Try REST API as fallback
             return $this->updateStoryPointsViaRestApi($issueKey, $storyPoints);
         } catch (\Exception $e) {
             Log::error("Error updating story points for {$issueKey}: " . $e->getMessage());
+
             return false;
         }
     }
@@ -192,6 +222,7 @@ class JiraService
 
             if ($httpCode !== 200) {
                 Log::error("Failed to get issue metadata for {$issueKey}");
+
                 return false;
             }
 
@@ -210,8 +241,9 @@ class JiraService
                 }
             }
 
-            if (!$storyPointsField) {
+            if (! $storyPointsField) {
                 Log::warning("Story points field not found for issue {$issueKey}");
+
                 return false;
             }
 
@@ -240,14 +272,17 @@ class JiraService
 
             if ($httpCode === 204 || $httpCode === 200) {
                 Log::info("Successfully updated story points for {$issueKey} to {$storyPoints} via REST API");
+
                 return true;
             }
 
             Log::error("Failed to update story points for {$issueKey}: HTTP {$httpCode}");
+
             return false;
 
         } catch (\Exception $e) {
             Log::error("Error updating story points via REST API for {$issueKey}: " . $e->getMessage());
+
             return false;
         }
     }
@@ -282,14 +317,13 @@ class JiraService
     /**
      * Search issues by JQL query
      *
-     * @param string $jql
-     * @param int $maxResults
      * @return array<int, object>
+     *
      * @throws JiraException
      */
     public function searchByJql(string $jql, int $maxResults = 100): array
     {
-        if (!$this->issueService) {
+        if (! $this->issueService) {
             throw new \RuntimeException('Jira service not initialized.');
         }
 
@@ -299,6 +333,7 @@ class JiraService
                 maxResults: $maxResults,
                 expand: 'renderedFields',
             );
+
             return $response->getIssues();
         } catch (JiraException $e) {
             Log::error('Jira JQL search error: ' . $e->getMessage());
@@ -309,7 +344,7 @@ class JiraService
     /**
      * Get multiple issues by their keys
      *
-     * @param array<string> $keys
+     * @param  array<string>  $keys
      * @return array<int, object>
      */
     public function getIssuesByKeys(array $keys): array
@@ -326,6 +361,7 @@ class JiraService
             return $this->searchByJql($jql, count($keys));
         } catch (JiraException $e) {
             Log::error('Failed to get issues by keys: ' . $e->getMessage());
+
             return [];
         }
     }
@@ -342,9 +378,11 @@ class JiraService
 
         try {
             $issues = $this->getIssuesByKeys([$key]);
+
             return $issues[0] ?? null;
         } catch (\Throwable $e) {
             Log::error('Failed to fetch Jira issue by key: ' . $e->getMessage());
+
             return null;
         }
     }
@@ -352,7 +390,7 @@ class JiraService
     /**
      * Parse user input to extract JQL, filter ID, or issue keys
      *
-     * @param string $input URL, filter ID, or comma-separated issue keys
+     * @param  string  $input  URL, filter ID, or comma-separated issue keys
      * @return array{type: string, value: string|array<string>}
      */
     public function parseJiraInput(string $input): array
@@ -384,9 +422,6 @@ class JiraService
 
     /**
      * Get JQL from a filter ID
-     *
-     * @param string $filterId
-     * @return string|null
      */
     public function getFilterJql(string $filterId): ?string
     {
@@ -400,7 +435,6 @@ class JiraService
     /**
      * Make a generic API request to Jira
      *
-     * @param string $url
      * @return array<mixed>|null
      */
     private function makeApiRequest(string $url): ?array
@@ -424,9 +458,11 @@ class JiraService
             }
 
             Log::warning("Jira API request failed: HTTP {$httpCode} for {$url}");
+
             return null;
         } catch (\Exception $e) {
             Log::error('Jira API request error: ' . $e->getMessage());
+
             return null;
         }
     }
@@ -438,7 +474,7 @@ class JiraService
      */
     public function testConnection(): array
     {
-        if (!$this->issueService) {
+        if (! $this->issueService) {
             return ['success' => false];
         }
 
@@ -462,6 +498,7 @@ class JiraService
 
             if ($httpCode === 200) {
                 $userData = json_decode($response, true);
+
                 return [
                     'success' => true,
                     'username' => $userData['displayName'] ?? $userData['name'] ?? '',
@@ -471,6 +508,7 @@ class JiraService
             return ['success' => false];
         } catch (\Exception $e) {
             Log::error('Jira connection test failed: ' . $e->getMessage());
+
             return ['success' => false];
         }
     }

--- a/database/factories/IssueFactory.php
+++ b/database/factories/IssueFactory.php
@@ -2,11 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Issue;
 use App\Models\Session;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Issue>
+ * @extends Factory<Issue>
  */
 class IssueFactory extends Factory
 {
@@ -26,5 +27,14 @@ class IssueFactory extends Factory
             'estimate_unit' => 'sp',
             'issue_type' => fake()->randomElement(['Story', 'Task', 'Spike', 'Bug']),
         ];
+    }
+
+    public function withParent(): static
+    {
+        return $this->state(fn(array $attributes) => [
+            'parent_key' => 'PROJ-' . fake()->numberBetween(1, 999),
+            'parent_title' => fake()->sentence(),
+            'parent_url' => fake()->url(),
+        ]);
     }
 }

--- a/database/migrations/2026_06_24_095455_add_parent_fields_to_issues_table.php
+++ b/database/migrations/2026_06_24_095455_add_parent_fields_to_issues_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('issues', function (Blueprint $table) {
+            $table->string('parent_key')->nullable()->after('issue_type');
+            $table->string('parent_title')->nullable()->after('parent_key');
+            $table->string('parent_url')->nullable()->after('parent_title');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('issues', function (Blueprint $table) {
+            $table->dropColumn(['parent_key', 'parent_title', 'parent_url']);
+        });
+    }
+};

--- a/resources/views/components/parent-issue-link.blade.php
+++ b/resources/views/components/parent-issue-link.blade.php
@@ -1,0 +1,40 @@
+@props([
+    'key' => null,
+    'title' => null,
+    'url' => null,
+])
+
+@php
+    $key = is_string($key) ? trim($key) : '';
+    $title = is_string($title) ? trim($title) : '';
+    $url = is_string($url) ? trim($url) : '';
+@endphp
+
+@if ($key !== '')
+    @if ($url !== '')
+        <a href="{{ $url }}" target="_blank" rel="nofollow"
+            class="badge badge-xs badge-error badge-outline inline-flex items-center gap-1 hover:bg-error hover:text-error-content"
+            title="{{ $title }}">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+            <span class="font-medium">{{ $key }}</span>
+            @if ($title !== '')
+                <span class="truncate max-w-[18ch] hidden sm:inline">· {{ $title }}</span>
+            @endif
+        </a>
+    @else
+        <span class="badge badge-xs badge-outline badge-secondary inline-flex items-center gap-1"
+            title="{{ $title }}">
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+            <span class="font-medium">{{ $key }}</span>
+            @if ($title !== '')
+                <span class="truncate max-w-[18ch] hidden sm:inline">· {{ $title }}</span>
+            @endif
+        </span>
+    @endif
+@endif

--- a/resources/views/livewire/archived-session-view.blade.php
+++ b/resources/views/livewire/archived-session-view.blade.php
@@ -10,7 +10,9 @@
     <div class="bg-base-300 rounded-xl shadow-md border border-base-300 p-5 sm:p-6 mb-6">
         <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <div class="min-w-0">
-                <div class="text-xs uppercase tracking-wide text-base-content/60 mb-1 badge badge-warning text-warning-content">Archivierte Session</div>
+                <div
+                    class="text-xs uppercase tracking-wide text-base-content/60 mb-1 badge badge-warning text-warning-content">
+                    Archivierte Session</div>
                 <h1 class="text-xl sm:text-2xl font-semibold text-base-content">
                     Session: <span class="font-bold">{{ $session->name }}</span>
                 </h1>
@@ -25,7 +27,7 @@
                     <a href="{{ route('dashboard') }}" class="btn btn-sm btn-outline">
                         Zur Übersicht
                     </a>
-                    @if($isOwner)
+                    @if ($isOwner)
                         <button wire:click="unarchiveSession" class="btn btn-sm btn-success">
                             Reaktivieren
                         </button>
@@ -49,7 +51,7 @@
                         wire:key="archived-issue-{{ $issue->id }}">
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                             <div class="min-w-0">
-                                @if($issue->jira_url || $issue->jira_key)
+                                @if ($issue->jira_url || $issue->jira_key)
                                     <a href="{{ $issue->getJiraBrowserUrl() }}" target="_blank" rel="nofollow"
                                         class="inline-flex items-center gap-1 text-xs text-info hover:underline mb-0.5">
                                         <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
@@ -60,6 +62,7 @@
                                     </a>
                                 @endif
                                 <div class="flex items-center gap-2">
+                                    <x-parent-issue-link :key="$issue->parent_key" :title="$issue->parent_title" :url="$issue->parent_url" />
                                     <x-issue-type-badge :type="$issue->issue_type" />
                                 </div>
                                 <div class="text-sm sm:text-base font-semibold text-base-content break-words">
@@ -68,7 +71,8 @@
                             </div>
                             <div class="flex items-center gap-2 sm:justify-end sm:shrink-0">
                                 <span class="badge badge-success badge-outline whitespace-nowrap">
-                                    {{ $issue->storypoints ?? '—' }} {{ ($issue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP' }}
+                                    {{ $issue->storypoints ?? '—' }}
+                                    {{ ($issue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP' }}
                                 </span>
                             </div>
                         </div>
@@ -82,4 +86,3 @@
         </div>
     </div>
 </div>
-

--- a/resources/views/livewire/async-voting-cards.blade.php
+++ b/resources/views/livewire/async-voting-cards.blade.php
@@ -8,19 +8,18 @@
             Async schätzen
         </h2>
 
-        @if(!$selectedIssue)
+        @if (!$selectedIssue)
             <div class="text-sm text-base-content/70 mt-2">
                 Wähle unten ein Issue aus, um deine Vorab-Schätzung abzugeben.
             </div>
         @else
             <div class="mt-3">
-                @if($selectedIssue->jira_url || $selectedIssue->jira_key)
-                    <a href="{{ $selectedIssue->getJiraBrowserUrl() }}"
-                        target="_blank"
-                        rel="nofollow"
+                @if ($selectedIssue->jira_url || $selectedIssue->jira_key)
+                    <a href="{{ $selectedIssue->getJiraBrowserUrl() }}" target="_blank" rel="nofollow"
                         class="inline-flex items-center gap-1 text-xs text-info hover:underline mb-1">
                         <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.005-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.758a1.001 1.001 0 0 0-1.001-1.001zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.005 1.005 0 0 0 23.013 0z"/>
+                            <path
+                                d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.005-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.758a1.001 1.001 0 0 0-1.001-1.001zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.005 1.005 0 0 0 23.013 0z" />
                         </svg>
                         {{ $selectedIssue->jira_key ?? 'Jira öffnen' }}
                     </a>
@@ -30,24 +29,27 @@
                     {{ $selectedIssue->title }}
                 </div>
                 <div class="mt-1 flex items-center gap-2">
+                    <x-parent-issue-link :key="$selectedIssue->parent_key" :title="$selectedIssue->parent_title" :url="$selectedIssue->parent_url" />
                     <x-issue-type-badge :type="$selectedIssue->issue_type" />
                 </div>
 
-                @if($selectedIssue->description)
+                @if ($selectedIssue->description)
                     <div x-data="{ expanded: false }" class="mt-2">
                         <div class="relative">
                             <div class="text-base-content text-sm prose prose-sm max-w-none jira-description"
-                                 :class="expanded ? '' : 'max-h-16 overflow-hidden'">
+                                :class="expanded ? '' : 'max-h-16 overflow-hidden'">
                                 {!! $selectedIssue->formatted_description !!}
                             </div>
                             <div x-show="!expanded"
-                                 class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-base-200 to-transparent pointer-events-none">
+                                class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-base-200 to-transparent pointer-events-none">
                             </div>
                         </div>
                         <button @click="expanded = !expanded" class="btn btn-sm btn-ghost mt-2 gap-1">
                             <span x-text="expanded ? 'Weniger anzeigen' : 'Mehr lesen'"></span>
-                            <svg class="w-4 h-4 transition-transform" :class="expanded ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                            <svg class="w-4 h-4 transition-transform" :class="expanded ? 'rotate-180' : ''"
+                                fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M19 9l-7 7-7-7" />
                             </svg>
                         </button>
                     </div>
@@ -56,7 +58,7 @@
                 <div class="mt-4 pt-4 border-t border-base-content/10">
                     <div class="flex items-center justify-between gap-3 mb-3">
                         <div class="text-sm font-semibold">Deine Schätzung</div>
-                        @if($myVote !== null)
+                        @if ($myVote !== null)
                             <span class="badge badge-success badge-outline">
                                 Gespeichert
                             </span>
@@ -64,19 +66,17 @@
                     </div>
 
                     <div class="grid grid-cols-4 sm:grid-cols-8 gap-2">
-                        @foreach($cards as $card)
+                        @foreach ($cards as $card)
                             @php
                                 $isSelected = $selectedCard === $card;
                                 $isMyVote = $myVote === $card;
                             @endphp
-                            <button
-                                wire:key="async-card-{{ $card }}"
-                                wire:click="chooseCard({{ $card }})"
-                                @class([
+                            <button wire:key="async-card-{{ $card }}"
+                                wire:click="chooseCard({{ $card }})" @class([
                                     'btn btn-lg font-bold',
                                     'btn-primary' => $isSelected,
-                                    'btn-ghost bg-base-content/10 hover:bg-base-content/20' => ! $isSelected,
-                                    'ring-2 ring-success/40' => $isMyVote && ! $isSelected,
+                                    'btn-ghost bg-base-content/10 hover:bg-base-content/20' => !$isSelected,
+                                    'ring-2 ring-success/40' => $isMyVote && !$isSelected,
                                 ])>
                                 {{ $card }}
                             </button>
@@ -88,7 +88,7 @@
                             Abbrechen
                         </button>
                         <div class="flex-1"></div>
-                        @if($myVote !== null)
+                        @if ($myVote !== null)
                             <button wire:click="removeVote" class="btn btn-warning">
                                 Vote entfernen
                             </button>
@@ -102,5 +102,3 @@
         @endif
     </div>
 </div>
-
-

--- a/resources/views/livewire/async-voting-page.blade.php
+++ b/resources/views/livewire/async-voting-page.blade.php
@@ -14,12 +14,13 @@
                     Session: <span class="font-bold">{{ $session->name }}</span>
                 </h1>
                 <div class="mt-1 text-xs sm:text-sm text-base-content/70">
-                    @if($isOwner)
+                    @if ($isOwner)
                         Zeigt nur, <span class="font-semibold">wer</span> geschätzt hat – keine Werte.
                     @elseif($canVote)
                         Vorab-Schätzungen ohne Live-Runde. Finale Storypoints setzt der Owner im Session Screen.
                     @else
-                        Du bist als Zuschauer eingetragen – keine Vorab-Schätzung. Nutze die Live-Session, um Ergebnisse zu sehen.
+                        Du bist als Zuschauer eingetragen – keine Vorab-Schätzung. Nutze die Live-Session, um Ergebnisse
+                        zu sehen.
                     @endif
                 </div>
             </div>
@@ -34,7 +35,7 @@
         </div>
     </div>
 
-    @if($isOwner)
+    @if ($isOwner)
         {{-- Owner Progress View --}}
         <div class="card bg-base-200 shadow-lg border border-base-300">
             <div class="card-body p-5 sm:p-6">
@@ -46,13 +47,13 @@
                     Vorab-Schätzungen (Fortschritt)
                 </h2>
 
-                @if($openIssues->isEmpty())
+                @if ($openIssues->isEmpty())
                     <div class="text-sm text-base-content/60 mt-2">
                         Keine offenen Issues.
                     </div>
                 @else
                     <div class="divide-y divide-base-300 mt-3">
-                        @foreach($openIssues as $issue)
+                        @foreach ($openIssues as $issue)
                             @php
                                 $voters = $asyncVotersByIssue[$issue->id] ?? [];
                                 $votersShown = array_slice($voters, 0, 10);
@@ -61,7 +62,7 @@
                             <div class="py-4">
                                 <div class="flex items-start justify-between gap-4">
                                     <div class="min-w-0">
-                                        @if($issue->jira_url || $issue->jira_key)
+                                        @if ($issue->jira_url || $issue->jira_key)
                                             <a href="{{ $issue->jira_url ?? '#' }}" target="_blank" rel="nofollow"
                                                 class="inline-flex items-center gap-1 text-xs text-info hover:underline mb-0.5">
                                                 <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
@@ -83,29 +84,37 @@
                                 </div>
 
                                 <div class="mt-3 flex items-center flex-wrap gap-2">
-                                    @if(!empty($voters))
+                                    @if (!empty($voters))
                                         <div class="flex -space-x-2">
-                                            @foreach($votersShown as $voter)
+                                            @foreach ($votersShown as $voter)
                                                 @php
                                                     $name = (string) $voter['name'];
                                                     $parts = preg_split('/\s+/', trim($name)) ?: [];
-                                                    $initials = collect($parts)->filter()->take(2)->map(fn ($p) => mb_strtoupper(mb_substr($p, 0, 1)))->implode('');
+                                                    $initials = collect($parts)
+                                                        ->filter()
+                                                        ->take(2)
+                                                        ->map(fn($p) => mb_strtoupper(mb_substr($p, 0, 1)))
+                                                        ->implode('');
                                                     if ($initials === '' && $name !== '') {
                                                         $initials = mb_strtoupper(mb_substr($name, 0, 2));
                                                     }
                                                 @endphp
                                                 <div class="tooltip" data-tip="{{ $name }}">
                                                     <div class="avatar avatar-placeholder">
-                                                        <div class="bg-success/15 text-success rounded-full w-8 h-8 ring-2 ring-success/30 flex items-center justify-center">
-                                                            <span class="text-[11px] font-semibold leading-none">{{ $initials }}</span>
+                                                        <div
+                                                            class="bg-success/15 text-success rounded-full w-8 h-8 ring-2 ring-success/30 flex items-center justify-center">
+                                                            <span
+                                                                class="text-[11px] font-semibold leading-none">{{ $initials }}</span>
                                                         </div>
                                                     </div>
                                                 </div>
                                             @endforeach
-                                            @if($remaining > 0)
+                                            @if ($remaining > 0)
                                                 <div class="avatar avatar-placeholder">
-                                                    <div class="bg-base-300 text-base-content rounded-full w-8 h-8 ring-2 ring-base-300 flex items-center justify-center">
-                                                        <span class="text-[11px] font-semibold leading-none">+{{ $remaining }}</span>
+                                                    <div
+                                                        class="bg-base-300 text-base-content rounded-full w-8 h-8 ring-2 ring-base-300 flex items-center justify-center">
+                                                        <span
+                                                            class="text-[11px] font-semibold leading-none">+{{ $remaining }}</span>
                                                     </div>
                                                 </div>
                                             @endif
@@ -128,7 +137,7 @@
     @elseif($canVote)
         {{-- Voter Async Voting View (v2-style) --}}
         <div class="min-w-0 space-y-6">
-            <livewire:async-voting-cards :session="$session" :key="'async-v2-cards-'.$session->id" />
+            <livewire:async-voting-cards :session="$session" :key="'async-v2-cards-' . $session->id" />
 
             {{-- Not yet voted --}}
             <div class="card bg-base-200 shadow-lg border border-base-300">
@@ -143,22 +152,20 @@
                     </h2>
                 </div>
                 <div class="p-0">
-                    @if($notVotedIssues->isEmpty())
+                    @if ($notVotedIssues->isEmpty())
                         <div class="p-6 text-center text-base-content/50 text-sm">
                             Alles erledigt 🎉
                         </div>
                     @else
                         <ul class="divide-y divide-base-300">
-                            @foreach($notVotedIssues as $issue)
+                            @foreach ($notVotedIssues as $issue)
                                 <li wire:key="async-notvoted-{{ $issue->id }}"
-                                    class="p-4 hover:bg-base-300/50 transition-colors cursor-pointer"
-                                    x-data
+                                    class="p-4 hover:bg-base-300/50 transition-colors cursor-pointer" x-data
                                     @click="$dispatch('async-select-issue', { issueId: {{ $issue->id }} })">
                                     <div class="flex items-center justify-between gap-3">
                                         <div class="min-w-0">
-                                            @if($issue->jira_url || $issue->jira_key)
-                                                <a href="{{ $issue->getJiraBrowserUrl() }}"
-                                                    target="_blank"
+                                            @if ($issue->jira_url || $issue->jira_key)
+                                                <a href="{{ $issue->getJiraBrowserUrl() }}" target="_blank"
                                                     rel="nofollow"
                                                     class="inline-flex items-center gap-1 text-xs text-info hover:underline mb-0.5"
                                                     @click.stop>
@@ -170,9 +177,12 @@
                                                 </a>
                                             @endif
                                             <div class="flex items-center gap-2">
+                                                <x-parent-issue-link :key="$issue->parent_key" :title="$issue->parent_title"
+                                                    :url="$issue->parent_url" />
                                                 <x-issue-type-badge :type="$issue->issue_type" />
                                             </div>
-                                            <div class="font-medium text-base-content truncate">{{ $issue->title }}</div>
+                                            <div class="font-medium text-base-content truncate">{{ $issue->title }}
+                                            </div>
                                         </div>
                                         <span class="badge badge-accent">schätzen</span>
                                     </div>
@@ -196,25 +206,23 @@
                     </h2>
                 </div>
                 <div class="p-0">
-                    @if($votedIssues->isEmpty())
+                    @if ($votedIssues->isEmpty())
                         <div class="p-6 text-center text-base-content/50 text-sm">
                             Noch keine Vorab-Schätzungen gespeichert.
                         </div>
                     @else
                         <ul class="divide-y divide-base-300">
-                            @foreach($votedIssues as $issue)
+                            @foreach ($votedIssues as $issue)
                                 @php
                                     $voteVal = $myVotesByIssue[$issue->id] ?? null;
                                 @endphp
                                 <li wire:key="async-voted-{{ $issue->id }}"
-                                    class="p-4 hover:bg-base-300/50 transition-colors cursor-pointer"
-                                    x-data
+                                    class="p-4 hover:bg-base-300/50 transition-colors cursor-pointer" x-data
                                     @click="$dispatch('async-select-issue', { issueId: {{ $issue->id }} })">
                                     <div class="flex items-center justify-between gap-3">
                                         <div class="min-w-0">
-                                            @if($issue->jira_url || $issue->jira_key)
-                                                <a href="{{ $issue->getJiraBrowserUrl() }}"
-                                                    target="_blank"
+                                            @if ($issue->jira_url || $issue->jira_key)
+                                                <a href="{{ $issue->getJiraBrowserUrl() }}" target="_blank"
                                                     rel="nofollow"
                                                     class="inline-flex items-center gap-1 text-xs text-info hover:underline mb-0.5"
                                                     @click.stop>
@@ -226,24 +234,28 @@
                                                 </a>
                                             @endif
                                             <div class="flex items-center gap-2">
+                                                <x-parent-issue-link :key="$issue->parent_key" :title="$issue->parent_title"
+                                                    :url="$issue->parent_url" />
                                                 <x-issue-type-badge :type="$issue->issue_type" />
                                             </div>
-                                            <div class="font-medium text-base-content truncate">{{ $issue->title }}</div>
+                                            <div class="font-medium text-base-content truncate">{{ $issue->title }}
+                                            </div>
                                         </div>
                                         <div class="flex items-center gap-2 shrink-0">
                                             <span class="badge badge-success badge-outline whitespace-nowrap shrink-0">
-                                                {{ $voteVal }} {{ ($issue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP' }}
+                                                {{ $voteVal }}
+                                                {{ ($issue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP' }}
                                             </span>
-                                            <button
-                                                type="button"
+                                            <button type="button"
                                                 class="btn btn-ghost btn-sm btn-square text-error tooltip tooltip-left"
                                                 wire:click.prevent="revokeAsyncVote({{ $issue->id }})"
                                                 wire:confirm="Vorab-Schätzung widerrufen? (Das Ticket bleibt erhalten.)"
-                                                @click.stop
-                                                aria-label="Vorab-Schätzung widerrufen"
+                                                @click.stop aria-label="Vorab-Schätzung widerrufen"
                                                 data-tip="Vorab-Schätzung widerrufen">
-                                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                <svg class="w-4 h-4" fill="none" stroke="currentColor"
+                                                    viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round"
+                                                        stroke-width="2"
                                                         d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                                                 </svg>
                                             </button>
@@ -258,13 +270,17 @@
         </div>
     @else
         <div class="alert alert-info shadow-lg">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                class="stroke-current shrink-0 w-6 h-6">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                    d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
             </svg>
             <div>
                 <div class="font-semibold">Nur Zuschauer</div>
-                <div class="text-sm">Vorab-Schätzungen sind für dich nicht verfügbar. Wechsle zur Live-Session, um das Voting zu verfolgen.</div>
-                <a href="{{ route('session.voting', $session->invite_code) }}" class="btn btn-sm btn-primary mt-3">Zur Live-Session</a>
+                <div class="text-sm">Vorab-Schätzungen sind für dich nicht verfügbar. Wechsle zur Live-Session, um das
+                    Voting zu verfolgen.</div>
+                <a href="{{ route('session.voting', $session->invite_code) }}"
+                    class="btn btn-sm btn-primary mt-3">Zur Live-Session</a>
             </div>
         </div>
     @endif

--- a/resources/views/livewire/v2/partials/_issue-list-finished.blade.php
+++ b/resources/views/livewire/v2/partials/_issue-list-finished.blade.php
@@ -11,7 +11,7 @@
         </h2>
     </div>
     <div class="p-0">
-        @if($finishedIssues->isEmpty())
+        @if ($finishedIssues->isEmpty())
             <div class="p-8 text-center text-base-content/50">
                 <svg class="w-12 h-12 mx-auto mb-2 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
@@ -21,12 +21,13 @@
             </div>
         @else
             <ul class="divide-y divide-base-300">
-                @foreach($finishedIssues as $issue)
-                    <li wire:key="finished-issue-{{ $issue->id }}" class="p-4 hover:bg-base-300/50 transition-colors">
+                @foreach ($finishedIssues as $issue)
+                    <li wire:key="finished-issue-{{ $issue->id }}"
+                        class="p-4 hover:bg-base-300/50 transition-colors">
                         <div class="flex items-start gap-3">
                             <div class="flex-1 min-w-0">
                                 <div class="flex items-center gap-2 mb-0.5">
-                                    @if($issue->jira_url || $issue->jira_key)
+                                    @if ($issue->jira_url || $issue->jira_key)
                                         <a href="{{ $issue->jira_url ?? '#' }}" target="_blank" rel="nofollow"
                                             class="inline-flex items-center gap-1 text-xs text-info hover:underline">
                                             <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
@@ -36,6 +37,7 @@
                                             {{ $issue->jira_key }}
                                         </a>
                                     @endif
+                                    <x-parent-issue-link :key="$issue->parent_key" :title="$issue->parent_title" :url="$issue->parent_url" />
                                     <x-issue-type-badge :type="$issue->issue_type" />
                                 </div>
                                 <p class="font-medium text-base-content truncate">
@@ -44,20 +46,21 @@
                             </div>
                             <div class="flex items-center gap-2">
                                 <span class="badge badge-success">
-                                    {{ $issue->storypoints ?? '?' }} {{ ($issue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP' }}
+                                    {{ $issue->storypoints ?? '?' }}
+                                    {{ ($issue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP' }}
                                 </span>
-                                @if($isOwner && $issue->jira_key)
-                                    <button
-                                        wire:click="refreshIssueFromJira({{ $issue->id }})"
+                                @if ($isOwner && $issue->jira_key)
+                                    <button wire:click="refreshIssueFromJira({{ $issue->id }})"
                                         class="btn btn-ghost btn-sm btn-square tooltip tooltip-left"
-                                        data-tip="Jira-Daten aktualisieren"
-                                        wire:loading.attr="disabled"
+                                        data-tip="Jira-Daten aktualisieren" wire:loading.attr="disabled"
                                         wire:target="refreshIssueFromJira">
-                                        <svg wire:loading.remove wire:target="refreshIssueFromJira" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <svg wire:loading.remove wire:target="refreshIssueFromJira" class="w-4 h-4"
+                                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                 d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 00-14.66-3.34M4 16a8 8 0 0014.66 3.34" />
                                         </svg>
-                                        <span wire:loading wire:target="refreshIssueFromJira" class="loading loading-spinner loading-xs"></span>
+                                        <span wire:loading wire:target="refreshIssueFromJira"
+                                            class="loading loading-spinner loading-xs"></span>
                                     </button>
                                 @endif
                             </div>

--- a/resources/views/livewire/v2/partials/_issue-list-open.blade.php
+++ b/resources/views/livewire/v2/partials/_issue-list-open.blade.php
@@ -11,14 +11,14 @@
         </h2>
     </div>
     <div class="p-0">
-        @if($openIssues->isEmpty())
+        @if ($openIssues->isEmpty())
             <div class="p-8 text-center text-base-content/50">
                 <svg class="w-12 h-12 mx-auto mb-2 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
                         d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <p class="text-sm mb-3">Keine offenen Issues</p>
-                @if($isOwner)
+                @if ($isOwner)
                     <button wire:click="$set('drawerOpen', true)" class="btn btn-primary btn-sm gap-1">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -28,7 +28,8 @@
                 @endif
             </div>
         @else
-            <ul class="divide-y divide-base-300" @if($isOwner) x-data x-init="
+            <ul class="divide-y divide-base-300"
+                @if ($isOwner) x-data x-init="
                 Sortable.create($el, {
                     animation: 150,
                     handle: '.drag-handle',
@@ -39,22 +40,23 @@
                     }
                 });
             " @endif>
-                @foreach($openIssues as $issue)
+                @foreach ($openIssues as $issue)
                     <li wire:key="open-issue-{{ $issue->id }}" class="p-4 hover:bg-base-300/50 transition-colors"
                         data-issue-id="{{ $issue->id }}">
                         <div class="flex items-center gap-3">
                             {{-- Drag Handle (nur für Owner) --}}
-                            @if($isOwner)
+                            @if ($isOwner)
                                 <div
                                     class="drag-handle cursor-grab active:cursor-grabbing text-base-content/40 hover:text-base-content">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 8h16M4 16h16" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M4 8h16M4 16h16" />
                                     </svg>
                                 </div>
                             @endif
                             <div class="flex-1 min-w-0">
-                                <div class="flex items-center gap-2 mb-0.5">
-                                    @if($issue->jira_url || $issue->jira_key)
+                                <div class="flex items-start gap-2 mb-0.5 flex-wrap">
+                                    @if ($issue->jira_url || $issue->jira_key)
                                         <a href="{{ $issue->jira_url ?? '#' }}" target="_blank" rel="nofollow"
                                             class="inline-flex items-center gap-1 text-xs text-info hover:underline">
                                             <svg class="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
@@ -64,16 +66,22 @@
                                             {{ $issue->jira_key }}
                                         </a>
                                     @endif
-                                    <x-issue-type-badge :type="$issue->issue_type" />
+                                    @if ($issue->parent_key)
+                                        <x-parent-issue-link :key="$issue->parent_key" :title="$issue->parent_title" :url="$issue->parent_url" />
+                                    @endif
                                 </div>
                                 <p class="font-medium text-base-content truncate">
+                                    @if ($issue->issue_type)
+                                        <x-issue-type-badge :type="$issue->issue_type" /> ·
+                                    @endif
                                     {{ $issue->title }}
                                 </p>
                             </div>
                             {{-- Buttons nur für Owner --}}
-                            @if($isOwner)
+                            @if ($isOwner)
                                 <div class="flex items-center gap-1">
-                                    <button wire:click="startVoting({{ $issue->id }})" class="btn btn-primary btn-sm gap-1">
+                                    <button wire:click="startVoting({{ $issue->id }})"
+                                        class="btn btn-primary btn-sm gap-1">
                                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                 d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
@@ -82,18 +90,18 @@
                                         </svg>
                                         Start
                                     </button>
-                                    @if($issue->jira_key)
-                                        <button
-                                            wire:click="refreshIssueFromJira({{ $issue->id }})"
+                                    @if ($issue->jira_key)
+                                        <button wire:click="refreshIssueFromJira({{ $issue->id }})"
                                             class="btn btn-ghost btn-sm btn-square tooltip tooltip-left"
-                                            data-tip="Jira-Daten aktualisieren"
-                                            wire:loading.attr="disabled"
+                                            data-tip="Jira-Daten aktualisieren" wire:loading.attr="disabled"
                                             wire:target="refreshIssueFromJira">
-                                            <svg wire:loading.remove wire:target="refreshIssueFromJira" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <svg wire:loading.remove wire:target="refreshIssueFromJira" class="w-4 h-4"
+                                                fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                     d="M4 4v6h6M20 20v-6h-6M20 8a8 8 0 00-14.66-3.34M4 16a8 8 0 0014.66 3.34" />
                                             </svg>
-                                            <span wire:loading wire:target="refreshIssueFromJira" class="loading loading-spinner loading-xs"></span>
+                                            <span wire:loading wire:target="refreshIssueFromJira"
+                                                class="loading loading-spinner loading-xs"></span>
                                         </button>
                                     @endif
                                     <button wire:click="deleteIssue({{ $issue->id }})"

--- a/resources/views/livewire/v2/partials/_voting-panel.blade.php
+++ b/resources/views/livewire/v2/partials/_voting-panel.blade.php
@@ -1,21 +1,19 @@
 {{-- Voting Panel - Aktuelles Issue --}}
-<div id="voting-panel"
-     x-data="{ issueId: {{ $currentIssue->id }} }"
-     x-init="
-         // Scroll beim ersten Erscheinen
-         setTimeout(() => {
-             $el.scrollIntoView({ behavior: 'smooth', block: 'start' });
-         }, 150);
-     "
-     class="card bg-base-300 text-base-content shadow-lg mb-6 border-2 border-primary scroll-mt-6">
+<div id="voting-panel" x-data="{ issueId: {{ $currentIssue->id }} }" x-init="// Scroll beim ersten Erscheinen
+setTimeout(() => {
+    $el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}, 150);"
+    class="card bg-base-300 text-base-content shadow-lg mb-6 border-2 border-primary scroll-mt-6">
     <div class="card-body p-5">
         {{-- Header: Status + Controls --}}
         <div class="flex items-center justify-between gap-2 mb-3">
             <span class="badge badge-lg badge-warning gap-2">
-                @if($votesRevealed)
+                @if ($votesRevealed)
                     <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                     </svg>
                     {{ count($votedUserIds) }} Stimmen
                 @else
@@ -26,25 +24,29 @@
 
             <div class="flex gap-2">
                 {{-- Owner Controls --}}
-                @if($isOwner)
-                    @if($votesRevealed)
+                @if ($isOwner)
+                    @if ($votesRevealed)
                         <button wire:click="hideVotes" class="btn btn-sm btn-warning gap-1">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21" />
                             </svg>
                             Verdecken
                         </button>
                         <button wire:click="restartVoting" class="btn btn-sm btn-secondary gap-1">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                             </svg>
                             Neu voten
                         </button>
                     @elseif(count($votedUserIds) > 0)
                         <button wire:click="revealVotes" class="btn btn-sm btn-success gap-1">
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                    d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                             </svg>
                             Aufdecken
                         </button>
@@ -53,7 +55,8 @@
                     {{-- Cancel Button (für alle Teilnehmer) --}}
                     <button wire:click="cancelVoting" class="btn btn-sm btn-error gap-1">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M6 18L18 6M6 6l12 12" />
                         </svg>
                         Abbrechen
                     </button>
@@ -62,17 +65,19 @@
             </div>
 
             {{-- Voter Controls --}}
-            @if($canVote && $myVote !== null && ! $votesRevealed)
+            @if ($canVote && $myVote !== null && !$votesRevealed)
                 <div class="flex gap-2">
                     <button wire:click="removeVote" class="btn btn-sm btn-warning gap-1">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M6 18L18 6M6 6l12 12" />
                         </svg>
                         Zurücknehmen
                     </button>
                     <button wire:click="cancelVoting" class="btn btn-sm btn-error gap-1">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M6 18L18 6M6 6l12 12" />
                         </svg>
                         Abbrechen
                     </button>
@@ -82,38 +87,37 @@
 
         {{-- Issue Info --}}
         <div class="flex items-center gap-2 mb-1">
-            @if($currentIssue->jira_url || $currentIssue->jira_key)
-                <a href="{{ $currentIssue->jira_url ?? '#' }}"
-                   target="_blank"
-                   rel="nofollow"
-                   class="inline-flex items-center gap-1 text-xs text-info hover:underline">
+            @if ($currentIssue->jira_url || $currentIssue->jira_key)
+                <a href="{{ $currentIssue->jira_url ?? '#' }}" target="_blank" rel="nofollow"
+                    class="inline-flex items-center gap-1 text-xs text-info hover:underline">
                     <svg class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.005-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.758a1.001 1.001 0 0 0-1.001-1.001zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.005 1.005 0 0 0 23.013 0z"/>
+                        <path
+                            d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.005-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.758a1.001 1.001 0 0 0-1.001-1.001zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.005 1.005 0 0 0 23.013 0z" />
                     </svg>
                     {{ $currentIssue->jira_key ?? 'Jira öffnen' }}
                 </a>
             @endif
+            <x-parent-issue-link :key="$currentIssue->parent_key" :title="$currentIssue->parent_title" :url="$currentIssue->parent_url" />
             <x-issue-type-badge :type="$currentIssue->issue_type" />
         </div>
         <h2 class="card-title text-lg">{{ $currentIssue->title }}</h2>
 
         {{-- Description mit Collapse --}}
-        @if($currentIssue->description)
+        @if ($currentIssue->description)
             <div x-data="{ expanded: false }" class="mt-2">
                 <div class="relative">
                     <div class="text-base-content text-sm prose prose-sm max-w-none jira-description"
-                         :class="expanded ? '' : 'max-h-16 overflow-hidden'"
-                         x-ref="content">
+                        :class="expanded ? '' : 'max-h-16 overflow-hidden'" x-ref="content">
                         {!! $currentIssue->formatted_description !!}
                     </div>
                     <div x-show="!expanded"
-                         class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-base-300 to-transparent pointer-events-none">
+                        class="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-base-300 to-transparent pointer-events-none">
                     </div>
                 </div>
-                <button @click="expanded = !expanded"
-                        class="btn btn-sm btn-primary mt-2 gap-1">
+                <button @click="expanded = !expanded" class="btn btn-sm btn-primary mt-2 gap-1">
                     <span x-text="expanded ? 'Weniger anzeigen' : 'Mehr lesen'"></span>
-                    <svg class="w-4 h-4 transition-transform" :class="expanded ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-4 h-4 transition-transform" :class="expanded ? 'rotate-180' : ''" fill="none"
+                        stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                     </svg>
                 </button>
@@ -121,8 +125,8 @@
         @endif
 
         {{-- Aktionsbereich --}}
-        <div class="{{ ($votesRevealed || !$isOwner) ? 'mt-4 pt-4 border-t border-base-content/20' : '' }}">
-            @if($votesRevealed)
+        <div class="{{ $votesRevealed || !$isOwner ? 'mt-4 pt-4 border-t border-base-content/20' : '' }}">
+            @if ($votesRevealed)
                 {{-- Ergebnis anzeigen --}}
                 <div class="text-xs text-base-content mb-2">
                     {{ $isOwner ? 'Schätzung bestätigen:' : 'Ergebnis:' }}
@@ -132,29 +136,30 @@
                         $voteCounts = collect($votesByUser)->values()->countBy()->sortKeys();
                         $unitSuffix = ($currentIssue->estimate_unit ?? 'sp') === 'hours' ? 'h' : 'SP';
                     @endphp
-                    @foreach($voteCounts as $vote => $count)
-                        @if($isOwner)
+                    @foreach ($voteCounts as $vote => $count)
+                        @if ($isOwner)
                             <button wire:click="confirmEstimate({{ $vote }})"
                                 class="btn btn-lg min-w-14 text-lg font-bold btn-success flex-col h-auto py-2">
                                 <span>{{ $vote }} {{ $unitSuffix }}</span>
                                 <span class="text-xs font-normal opacity-80">{{ $count }}x</span>
                             </button>
                         @else
-                            <div class="btn btn-lg min-w-14 text-lg font-bold btn-ghost bg-base-content/10 flex-col h-auto py-2 cursor-default no-animation">
+                            <div
+                                class="btn btn-lg min-w-14 text-lg font-bold btn-ghost bg-base-content/10 flex-col h-auto py-2 cursor-default no-animation">
                                 <span>{{ $vote }} {{ $unitSuffix }}</span>
                                 <span class="text-xs font-normal opacity-80">{{ $count }}x</span>
                             </div>
                         @endif
                     @endforeach
                 </div>
-                @if($isOwner)
+                @if ($isOwner)
                     <div class="text-xs text-base-content mt-3">
                         Klicke auf einen Wert, um die Schätzung zu bestätigen
                     </div>
                 @endif
             @else
                 {{-- Voting-Karten (für Voter) --}}
-                @if($canVote)
+                @if ($canVote)
                     <div x-data="{
                         cards: @js($cards),
                         vote(index) {
@@ -162,28 +167,23 @@
                                 $wire.submitVote(this.cards[index]);
                             }
                         }
-                    }"
-                    @keydown.1.window="vote(0)"
-                    @keydown.2.window="vote(1)"
-                    @keydown.3.window="vote(2)"
-                    @keydown.4.window="vote(3)"
-                    @keydown.5.window="vote(4)"
-                    @keydown.6.window="vote(5)"
-                    @keydown.7.window="vote(6)"
-                    @keydown.8.window="vote(7)">
-                        <div  class="items-center gap-2 text-xs text-base-content mb-4 inline-flex">
+                    }" @keydown.1.window="vote(0)" @keydown.2.window="vote(1)"
+                        @keydown.3.window="vote(2)" @keydown.4.window="vote(3)" @keydown.5.window="vote(4)"
+                        @keydown.6.window="vote(5)" @keydown.7.window="vote(6)" @keydown.8.window="vote(7)">
+                        <div class="items-center gap-2 text-xs text-base-content mb-4 inline-flex">
                             <span>Deine Schätzung:</span>
-                            <span data-tip="⌨️ Tasten 1-8" class="tooltip tooltip-right bg-base-100 text-base-content rounded-full w-4 h-4 flex items-center justify-center text-medium text-sm cursor-pointer">?</span>
+                            <span data-tip="⌨️ Tasten 1-8"
+                                class="tooltip tooltip-right bg-base-100 text-base-content rounded-full w-4 h-4 flex items-center justify-center text-medium text-sm cursor-pointer">?</span>
                         </div>
                         <div class="flex flex-wrap gap-3">
-                            @foreach($cards as $index => $card)
+                            @foreach ($cards as $index => $card)
                                 <button wire:key="voting-card-{{ $card }}"
                                     wire:click="submitVote({{ $card }})"
                                     class="btn tooltip btn-lg min-w-14 text-lg font-bold relative {{ $myVote == $card ? 'btn-warning' : 'btn-ghost bg-base-content/10 hover:bg-base-content/20' }}">
                                     {{ $card }}
                                     <div class="tooltip-content bg-transparent text-base-content">
                                         <div class="kbd">Hotkey: {{ $index + 1 }}</div>
-                                      </div>
+                                    </div>
                                 </button>
                             @endforeach
                         </div>
@@ -193,5 +193,3 @@
         </div>
     </div>
 </div>
-
-

--- a/tests/Feature/ArchiveSessionTest.php
+++ b/tests/Feature/ArchiveSessionTest.php
@@ -66,7 +66,8 @@ test('archived session view shows issue overview', function () {
         ->test(ArchivedSessionView::class, ['inviteCode' => $session->invite_code])
         ->assertSee('Archivierte Session', false)
         ->assertSee($issue->jira_key, false)
-        ->assertSee('8 SP', false);
+        ->assertSee('8', false)
+        ->assertSee('SP', false);
 });
 
 test('owner can unarchive session from archived view', function () {

--- a/tests/Feature/Services/JiraServiceTest.php
+++ b/tests/Feature/Services/JiraServiceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Models\User;
+use App\Services\JiraService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function createJiraService(): JiraService
+{
+    $user = User::factory()->create([
+        'jira_url' => 'https://jira.example.com',
+        'jira_user' => 'user@example.com',
+        'jira_api_key' => 'token',
+    ]);
+
+    return new JiraService($user);
+}
+
+test('mapJiraIssueToArray extracts parent issue data', function () {
+    $service = createJiraService();
+
+    $jiraIssue = (object) [
+        'key' => 'ABC-123',
+        'self' => 'https://jira.example.com/rest/api/2/issue/ABC-123',
+        'fields' => (object) [
+            'summary' => 'Story title',
+            'issuetype' => (object) ['name' => 'Story'],
+            'parent' => (object) [
+                'key' => 'ABC-100',
+                'self' => 'https://jira.example.com/rest/api/2/issue/ABC-100',
+                'fields' => (object) [
+                    'summary' => 'Epic title',
+                ],
+            ],
+        ],
+        'renderedFields' => [],
+    ];
+
+    $mapped = $service->mapJiraIssueToArray($jiraIssue);
+
+    expect($mapped)->toMatchArray([
+        'title' => 'Story title',
+        'jira_key' => 'ABC-123',
+        'jira_url' => 'https://jira.example.com/browse/ABC-123',
+        'issue_type' => 'Story',
+        'parent_key' => 'ABC-100',
+        'parent_title' => 'Epic title',
+        'parent_url' => 'https://jira.example.com/browse/ABC-100',
+        'estimate_unit' => 'sp',
+    ]);
+});
+
+test('mapJiraIssueToArray returns null parent data when no parent exists', function () {
+    $service = createJiraService();
+
+    $jiraIssue = (object) [
+        'key' => 'ABC-123',
+        'self' => 'https://jira.example.com/rest/api/2/issue/ABC-123',
+        'fields' => (object) [
+            'summary' => 'Story title',
+            'issuetype' => (object) ['name' => 'Story'],
+        ],
+        'renderedFields' => [],
+    ];
+
+    $mapped = $service->mapJiraIssueToArray($jiraIssue);
+
+    expect($mapped['parent_key'])->toBeNull();
+    expect($mapped['parent_title'])->toBeNull();
+    expect($mapped['parent_url'])->toBeNull();
+});
+
+test('mapJiraIssueToArray handles parent without summary', function () {
+    $service = createJiraService();
+
+    $jiraIssue = (object) [
+        'key' => 'ABC-123',
+        'self' => 'https://jira.example.com/rest/api/2/issue/ABC-123',
+        'fields' => (object) [
+            'summary' => 'Story title',
+            'issuetype' => (object) ['name' => 'Story'],
+            'parent' => (object) [
+                'key' => 'ABC-100',
+                'self' => 'https://jira.example.com/rest/api/2/issue/ABC-100',
+                'fields' => (object) [],
+            ],
+        ],
+        'renderedFields' => [],
+    ];
+
+    $mapped = $service->mapJiraIssueToArray($jiraIssue);
+
+    expect($mapped['parent_key'])->toBe('ABC-100');
+    expect($mapped['parent_title'])->toBeNull();
+    expect($mapped['parent_url'])->toBe('https://jira.example.com/browse/ABC-100');
+});

--- a/tests/Feature/V2/SessionPageTest.php
+++ b/tests/Feature/V2/SessionPageTest.php
@@ -458,12 +458,12 @@ test('confirm estimate triggers Jira sync when issue has Jira link (browse url)'
         'jira_url' => 'https://jira.example.com/browse/ABC-123',
     ]);
 
-    $mock = \Mockery::mock(SyncStoryPointsToJira::class);
+    $mock = Mockery::mock(SyncStoryPointsToJira::class);
     $mock->shouldReceive('sync')
         ->once()
         ->with(
-            \Mockery::on(fn($u) => $u instanceof User && $u->id === $owner->id),
-            \Mockery::on(fn($i) => $i instanceof Issue && $i->id === $issue->id && $i->storypoints === 8),
+            Mockery::on(fn($u) => $u instanceof User && $u->id === $owner->id),
+            Mockery::on(fn($i) => $i instanceof Issue && $i->id === $issue->id && $i->storypoints === 8),
         );
     app()->instance(SyncStoryPointsToJira::class, $mock);
 
@@ -524,8 +524,8 @@ test('owner can refresh an imported jira issue to fetch missing fields', functio
         'estimate_unit' => 'sp',
     ]);
 
-    // Intercept `new JiraService(...)` inside the Livewire action
-    $jiraMock = \Mockery::mock('overload:' . JiraService::class);
+    // Bind a mock JiraService into the container so the trait resolves it.
+    $jiraMock = Mockery::mock(JiraService::class);
     $jiraMock->shouldReceive('getIssueByKey')
         ->once()
         ->with('ABC-123')
@@ -538,8 +538,12 @@ test('owner can refresh an imported jira issue to fetch missing fields', functio
             'jira_key' => 'ABC-123',
             'jira_url' => 'https://jira.example.com/browse/ABC-123',
             'issue_type' => 'Spike',
+            'parent_key' => 'ABC-100',
+            'parent_title' => 'Epic Title',
+            'parent_url' => 'https://jira.example.com/browse/ABC-100',
             'estimate_unit' => 'hours',
         ]);
+    app()->bind(JiraService::class, fn() => $jiraMock);
 
     Livewire::actingAs($owner)
         ->test(SessionPage::class, ['inviteCode' => $session->invite_code])
@@ -549,6 +553,9 @@ test('owner can refresh an imported jira issue to fetch missing fields', functio
     expect($issue->title)->toBe('New title');
     expect($issue->description)->toBe('<p>desc</p>');
     expect($issue->issue_type)->toBe('Spike');
+    expect($issue->parent_key)->toBe('ABC-100');
+    expect($issue->parent_title)->toBe('Epic Title');
+    expect($issue->parent_url)->toBe('https://jira.example.com/browse/ABC-100');
     expect($issue->estimate_unit)->toBe('hours');
 });
 
@@ -896,6 +903,43 @@ test('hasJiraCredentials returns false when credentials missing', function () {
     // hasJiraCredentials ist eine public Methode, kann direkt aufgerufen werden
     $result = $component->instance()->hasJiraCredentials();
     expect($result)->toBeFalse();
+});
+
+test('voting panel renders parent issue link when issue has parent data', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+    $issue = Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::VOTING,
+        'parent_key' => 'ABC-100',
+        'parent_title' => 'Epic Title',
+        'parent_url' => 'https://jira.example.com/browse/ABC-100',
+    ]);
+
+    $component = createSessionPageComponent($session, $owner);
+    $component->set('currentIssue', $issue);
+
+    $component->assertSee('ABC-100');
+    $component->assertSee('Epic Title');
+    $component->assertSeeHtml('href="https://jira.example.com/browse/ABC-100"');
+});
+
+test('issue list renders parent issue link when issue has parent data', function () {
+    $session = createTestSession();
+    $owner = $session->owner;
+    Issue::factory()->create([
+        'session_id' => $session->id,
+        'status' => IssueStatus::NEW,
+        'parent_key' => 'ABC-100',
+        'parent_title' => 'Epic Title',
+        'parent_url' => 'https://jira.example.com/browse/ABC-100',
+    ]);
+
+    $component = createSessionPageComponent($session, $owner);
+
+    $component->assertSee('ABC-100');
+    $component->assertSee('Epic Title');
+    $component->assertSeeHtml('href="https://jira.example.com/browse/ABC-100"');
 });
 
 // ============================================================================


### PR DESCRIPTION
- Add parent_key, parent_title and parent_url columns to issues table
- Read fields.parent from Jira API and map to local issue fields
- Persist and refresh parent data during Jira import and refresh
- Add parent-issue-link Blade component rendered before issue type badge
- Render parent link in open/finished issue lists, voting panel, async views and archive
- Extend IssueFactory and tests for parent issue handling